### PR TITLE
ci: add fmt and vet to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,34 @@ permissions:
   pull-requests: read
 
 jobs:
+  format:
+    name: Go Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.2
+      - name: Download dependencies
+        run: go mod download
+      - name: Run formatting
+        run: go fmt ./...
+
+  vet:
+    name: Go Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.2
+      - name: Download dependencies
+        run: go mod download
+      - name: Run vet
+        run: go vet --json ./...
+
   test:
     name: Go Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Items

https://github.com/The-DevOps-Daily/terraform-provider-validatefx/issues/26

## Changes

- Added `fmt` and `vet` procedures to `ci.yml` workflow
