### PR TITLE
Add E.164 phone number validator for Terraform provider

### DIFF
--- a/internal/validators/phone.go
+++ b/internal/validators/phone.go
@@ -8,41 +8,42 @@ import (
 	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-// Ensure Phone implements frameworkvalidator.String
 var _ frameworkvalidator.String = Phone()
 
-// Phone returns a schema.String validator which enforces E.164 phone number format.
+// Phone returns a schema.String validator that ensures values follow the E.164 phone number format.
 func Phone() frameworkvalidator.String {
 	return phoneValidator{}
 }
 
 type phoneValidator struct{}
 
+// Description returns a plain-text description of the validator.
 func (phoneValidator) Description(_ context.Context) string {
-	return "value must be a valid phone number in E.164 format"
+	return "value must be a valid E.164 phone number (start with '+' followed by 1–15 digits)"
 }
 
+// MarkdownDescription returns a markdown-formatted description of the validator.
 func (phoneValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid phone number in E.164 format"
+	return "value must be a valid **E.164 phone number** (start with '+' followed by 1–15 digits)"
 }
 
+// ValidateString performs the actual phone number validation.
 func (phoneValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 
 	value := req.ConfigValue.ValueString()
-
 	if value == "" {
 		return
 	}
 
-	re := regexp.MustCompile(`^\+[1-9]\d{1,14}$`)
-	if !re.MatchString(value) {
+	e164Regex := regexp.MustCompile(`^\+[1-9]\d{1,14}$`)
+	if !e164Regex.MatchString(value) {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Phone Number",
-			fmt.Sprintf("Value %q is not a valid E.164 phone number", value),
+			fmt.Sprintf("Value %q is not a valid E.164 phone number. It must start with '+' followed by 1–15 digits.", value),
 		)
 	}
 }

--- a/internal/validators/phone_test.go
+++ b/internal/validators/phone_test.go
@@ -4,40 +4,103 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
+	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func TestPhoneValidator(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		wantErr  bool
-	}{
-		{"Valid US number", "+14155552671", false},
-		{"Valid India number", "+919876543210", false},
-		{"Valid UK number", "+442071838750", false},
-		{"Missing +", "14155552671", true},
-		{"Invalid country code", "+0123456789", true},
-		{"Too long", "+1234567890123456", true},
-		{"Letters", "abcd12345", true},
-		{"Invalid characters", "+-123456789", true},
+func TestPhoneValidatorValid(t *testing.T) {
+	t.Parallel()
+
+	validator := Phone()
+
+	validNumbers := []string{
+		"+14155552671",   // US
+		"+919876543210",  // India
+		"+442071838750",  // UK
+	}
+
+	for _, num := range validNumbers {
+		req := frameworkvalidator.StringRequest{
+			Path:        path.Root("phone"),
+			ConfigValue: types.StringValue(num),
+		}
+		resp := &frameworkvalidator.StringResponse{}
+
+		validator.ValidateString(context.Background(), req, resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("expected no diagnostics for valid number %q, got: %v", num, resp.Diagnostics)
+		}
+	}
+}
+
+func TestPhoneValidatorInvalid(t *testing.T) {
+	t.Parallel()
+
+	validator := Phone()
+
+	invalidNumbers := []string{
+		"14155552671",        // Missing +
+		"+0123456789",        // Invalid country code
+		"+1234567890123456",  // Too long
+		"abcd12345",          // Letters
+		"+-123456789",        // Invalid characters
+	}
+
+	for _, num := range invalidNumbers {
+		req := frameworkvalidator.StringRequest{
+			Path:        path.Root("phone"),
+			ConfigValue: types.StringValue(num),
+		}
+		resp := &frameworkvalidator.StringResponse{}
+
+		validator.ValidateString(context.Background(), req, resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected diagnostics for invalid number %q", num)
+		}
+
+		diag := resp.Diagnostics[0]
+		if diag.Severity() != frameworkdiag.SeverityError {
+			t.Fatalf("expected error diagnostic, got severity: %s", diag.Severity())
+		}
+		if diag.Summary() != "Invalid Phone Number" {
+			t.Fatalf("unexpected diagnostic summary: %s", diag.Summary())
+		}
+	}
+}
+
+func TestPhoneValidatorHandlesEmptyAndNull(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]frameworkvalidator.StringRequest{
+		"empty": {
+			Path:        path.Root("phone"),
+			ConfigValue: types.StringValue(""),
+		},
+		"null": {
+			Path:        path.Root("phone"),
+			ConfigValue: types.StringNull(),
+		},
+		"unknown": {
+			Path:        path.Root("phone"),
+			ConfigValue: types.StringUnknown(),
+		},
 	}
 
 	validator := Phone()
-	ctx := context.Background()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resp := &frameworkvalidator.StringResponse{
-				Diagnostics: diag.Diagnostics{},
-			}
-			req := frameworkvalidator.StringRequest{
-				ConfigValue: types.StringValue(tt.input),
-			}
-			validator.ValidateString(ctx, req, resp)
-			if (len(resp.Diagnostics) > 0) != tt.wantErr {
-				t.Errorf("Phone validator error = %v, wantErr %v", resp.Diagnostics, tt.wantErr)
+	for name, req := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &frameworkvalidator.StringResponse{}
+			validator.ValidateString(context.Background(), req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no diagnostics for case %q, got: %v", name, resp.Diagnostics)
 			}
 		})
 	}


### PR DESCRIPTION
### Related Issue
Fixes: [Issue #31]

### Summary
This PR implements a phone number validator supporting the E.164 format for the Terraform provider. The validator ensures that all input phone numbers:  

- Start with a '+' followed by the country code and subscriber number  
- Contain a maximum of 15 digits (excluding '+')  
- Only contain numeric characters after the '+'  

### Changes
- Added `internal/validators/phone.go` implementing the E.164 validator  
- Added `internal/validators/phone_test.go` with unit tests covering valid and invalid phone numbers  

This addition improves input validation and prevents misconfigured phone numbers in Terraform configurations.
