### PR TITLE
chore: update changelog for 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,40 @@
 
 ### Changes
 
-- Merge pull request #135 from The-DevOps-Daily/fix/string-length-integration (75379a4)
-- Merge pull request #132 from Madhur-Dodake/feat/string-length-validator-issue-105 (9b98b71) #105
-- Merge pull request #133 from The-DevOps-Daily/feature/cidr-validator (f1fc4b7) #100
-- Merge pull request #130 from Rachitb0611/docs/add-contributors-badge (9e90793)
-- Merge pull request #124 from cheese-cakee/main (501493a)
-- Merge pull request #125 from The-DevOps-Daily/auto-issue-creation (7a2eb13)
-- Merge pull request #1 from The-DevOps-Daily/main (7f165d6)
-- Merge pull request #123 from Madhur-Dodake/docs/os-installation-111 (3165060)
-- Merge pull request #120 from cheese-cakee/main (4e37890)
+- None.
 
 ### Dependency Updates
 
-- Merge pull request #128 from The-DevOps-Daily/dependabot/github_actions/actions/setup-go-6 (cb51c3e)
-- Merge pull request #129 from The-DevOps-Daily/dependabot/github_actions/goreleaser/goreleaser-action-6 (a69aba5)
-- Merge pull request #127 from The-DevOps-Daily/dependabot/github_actions/actions/upload-artifact-5 (e74f0ee)
-- Merge pull request #126 from The-DevOps-Daily/dependabot/github_actions/actions/checkout-5 (6babd66)
+- None.
 
+
+## [0.1.4] - 2025-10-30
+
+### Features
+
+- Add string length validator and expose the `validatefx_string_length` Terraform function with docs, examples, and integration coverage (`986d9c4`, `6b504be`, `75379a4`).
+- Introduce CIDR validation with Terraform function support, documentation, and scenario updates (`9a3037c`, `53cfc96`, `f1fc4b7`).
+
+### Improvements
+
+- Automate changelog maintenance and grouping via the new update script (`806046b`, `b8ccfe6`, `bf1765f`).
+- Add contributor workflow tooling including pre-commit hooks, issue templates, and Dependabot configuration (`4e37890`, `7a2eb13`, `501493a`, `7f165d6`).
+
+### Documentation
+
+- Publish OS-specific installation and troubleshooting guidance and add README contributor highlights (`3165060`, `9e90793`).
+
+### Bug Fixes
+
+- Resolve string length integration regressions uncovered during testing (`be9d1db`, `75379a4`).
+- Tidy the CIDR Terraform scenario formatting to keep integration output stable (`0809e49`).
+
+### Dependency Updates
+
+- Bump actions/setup-go from 5 to 6 (`cb51c3e`, `0e44d89`).
+- Bump goreleaser/goreleaser-action from 5 to 6 (`a69aba5`, `526fb34`).
+- Bump actions/upload-artifact from 4 to 5 (`e74f0ee`, `b9a95d6`).
+- Bump actions/checkout from 4 to 5 (`6babd66`, `1e87f4d`).
 
 
 ## [0.1.3] - 2025-10-28


### PR DESCRIPTION
## Summary
- update the changelog for 0.1.4 release dated 2025-10-30
- reset the unreleased section placeholders

## Testing
- not required