### PR TITLE
fix: configure release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,78 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\\<>&'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - feature
+      - enhancement
+      - semver:minor
+  - title: '🐛 Bug Fixes'
+    labels:
+      - bug
+      - bugfix
+      - fix
+      - semver:patch
+  - title: '🧰 Maintenance'
+    labels:
+      - chore
+      - maintenance
+      - refactor
+      - dependencies
+  - title: '📚 Documentation'
+    labels:
+      - documentation
+      - docs
+
+version-resolver:
+  major:
+    labels:
+      - breaking-change
+      - semver:major
+  minor:
+    labels:
+      - feature
+      - enhancement
+      - semver:minor
+  patch:
+    labels:
+      - bug
+      - bugfix
+      - fix
+      - semver:patch
+  default: patch
+
+exclude-labels:
+  - skip-changelog
+
+template: |
+  ## What's Changed
+  $CHANGES
+
+  ## Contributors
+  $CONTRIBUTORS
+
+autolabeler:
+  - label: documentation
+    files:
+      - '**/*.md'
+  - label: dependencies
+    files:
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/**'
+  - label: chore
+    title:
+      - '/^chore/i'
+  - label: feature
+    title:
+      - '/^feat/i'
+  - label: bug
+    title:
+      - '/^fix/i'
+
+replacers:
+  - search: '/Merge pull request #(\d+) from .*\n\n/'
+    replace: ''

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+  workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update_release_draft:
@@ -14,5 +18,7 @@ jobs:
     steps:
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a release-drafter config on the default branch
- update the workflow triggers and permissions so release-drafter can run
- ensure categories and labels align with GoReleaser workflow usage

## Testing
- YAML configuration validated manually (PyYAML unavailable)
