### PR TITLE
Add string_contains usage example

### DIFF
--- a/examples/functions/string_contains/function.tf
+++ b/examples/functions/string_contains/function.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    validatefx = {
+      source  = "The-DevOps-Daily/validatefx"
+      version = "0.0.1"
+    }
+  }
+}
+
+provider "validatefx" {}
+
+locals {
+  phrases = [
+    "Hello, Terraform!",
+    "ValidateFX is great",
+    "Infrastructure as Code",
+  ]
+
+  results = [
+    for phrase in local.phrases : {
+      value = phrase
+      valid = provider::validatefx::string_contains(phrase, ["Terraform", "ValidateFX"], true)
+    }
+  ]
+}
+
+output "string_contains_example" {
+  value = local.results
+}


### PR DESCRIPTION
## Summary
- add an examples/functions/string_contains/function.tf scenario showing how to call the new validator function
- demonstrate case-insensitive matching via the third argument

Closes #198