### PR TITLE
refactor/common string helper

### DIFF
--- a/internal/functions/between.go
+++ b/internal/functions/between.go
@@ -92,11 +92,3 @@ func (betweenFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 
 	resp.Result = function.NewResultData(basetypes.NewBoolValue(true))
 }
-
-func stringFrom(v types.String) string {
-	if v.IsNull() || v.IsUnknown() {
-		return ""
-	}
-
-	return v.ValueString()
-}

--- a/internal/functions/common.go
+++ b/internal/functions/common.go
@@ -79,3 +79,13 @@ func (f *stringValidationFunction) Run(ctx context.Context, req function.RunRequ
 
 	resp.Result = function.NewResultData(basetypes.NewBoolValue(true))
 }
+
+// stringFrom safely converts a Terraform framework String to a plain string,
+// returning an empty string for null/unknown values. Useful for optional
+// parameters passed as strings.
+func stringFrom(v types.String) string {
+	if v.IsNull() || v.IsUnknown() {
+		return ""
+	}
+	return v.ValueString()
+}


### PR DESCRIPTION
Refactor: centralize stringFrom helper in internal/functions/common.go and reuse in between.go to reduce duplication. No behavior changes; make validate passes.