### PR TITLE
feat/fuzz tests validators 114

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Example usage in `examples/basic/main.tf`.
 
 Open to PRs! Browse our [good first issues](https://github.com/The-DevOps-Daily/terraform-provider-validatefx/issues?q=is%3Aopen+label%3A"good+first+issue") to get started.
 
+### Fuzz Tests
+
+Go ships with native fuzzing support. We include fuzz tests for core string validators (email, URL, JSON) to harden them against edge cases.
+
+- Run a targeted fuzz (10s) for email:
+  - `go test ./internal/validators -run FuzzEmailValidator -fuzz FuzzEmailValidator -fuzztime=10s`
+- For URL or JSON, replace the function name accordingly (e.g., `FuzzURLValidator`, `FuzzJSONValidator`).
+- To fuzz all in the package for 1 minute:
+  - `go test ./internal/validators -fuzz Fuzz -fuzztime=1m`
+
+When the fuzzer finds a failure, it writes a minimizing corpus entry that becomes part of future test runs.
+
 ---
 
 ## 📜 License

--- a/internal/validators/email_fuzz_test.go
+++ b/internal/validators/email_fuzz_test.go
@@ -1,0 +1,51 @@
+package validators
+
+import (
+	"context"
+	"net/mail"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzEmailValidator fuzzes the Email() validator to ensure it never panics
+// and broadly agrees with net/mail.ParseAddress semantics. Empty, null, and
+// unknown are allowed by design and should not produce diagnostics.
+func FuzzEmailValidator(f *testing.F) {
+	// Seed with a few interesting cases
+	for _, s := range []string{
+		"", "a@b.com", "user.name+tag+sorting@example.com", "not-an-email", "missing-at.example.com",
+		"A@b.c", "plainaddress", "@nouser", "name@localhost", "foo@bar..com",
+	} {
+		f.Add(s)
+	}
+
+	v := Email()
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{
+			Path:        path.Root("email"),
+			ConfigValue: types.StringValue(s),
+		}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		// Empty strings are allowed (treated as no-op)
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty string should not error, got %v", resp.Diagnostics)
+			}
+			return
+		}
+
+		// Cross-check with net/mail.ParseAddress
+		_, err := mail.ParseAddress(s)
+		hasErr := err != nil
+		if hasErr != resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch: ParseAddress error=%v, diagnostics.HasError=%v (value=%q)", hasErr, resp.Diagnostics.HasError(), s)
+		}
+	})
+}

--- a/internal/validators/json_fuzz_test.go
+++ b/internal/validators/json_fuzz_test.go
@@ -1,0 +1,47 @@
+package validators
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzJSONValidator validates robustness against arbitrary inputs and checks that
+// strings which unmarshal to JSON objects are accepted while others are rejected.
+func FuzzJSONValidator(f *testing.F) {
+	for _, s := range []string{
+		"", "{}", "{\"a\":1}", "[]", "true", "null", "{]", "{\"nested\": {\"b\":2}}",
+	} {
+		f.Add(s)
+	}
+
+	v := JSON()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("json"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error: %v", resp.Diagnostics)
+			}
+			return
+		}
+
+		var decoded any
+		err := json.Unmarshal([]byte(s), &decoded)
+		ok := err == nil
+		if ok {
+			_, ok = decoded.(map[string]any)
+		}
+
+		if ok != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch: decoded-object=%v diagnostics.HasError=%v value=%q", ok, resp.Diagnostics.HasError(), s)
+		}
+	})
+}

--- a/internal/validators/url_fuzz_test.go
+++ b/internal/validators/url_fuzz_test.go
@@ -1,0 +1,49 @@
+package validators
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzURLValidator ensures the URL() validator remains robust for arbitrary inputs
+// and aligns with url.ParseRequestURI expectations for basic validity (scheme+host present).
+func FuzzURLValidator(f *testing.F) {
+	seeds := []string{
+		"", "http://example.com", "https://example.com/path?x=1#frag", "ftp://example.com", "://bad", "http:/bad", "https://", "http://",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := URL()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("url"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error: %v", resp.Diagnostics)
+			}
+			return
+		}
+
+		parsed, err := url.ParseRequestURI(s)
+		basicValid := err == nil && parsed != nil && parsed.Scheme != "" && parsed.Host != ""
+
+		// Our validator only permits http/https schemes.
+		if basicValid && parsed.Scheme != "http" && parsed.Scheme != "https" {
+			basicValid = false
+		}
+
+		if basicValid != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch: basicValid=%v diagnostics.HasError=%v value=%q", basicValid, resp.Diagnostics.HasError(), s)
+		}
+	})
+}


### PR DESCRIPTION
Adds fuzz tests for Email, URL, and JSON validators. Includes README guidance on running fuzzing locally. Closes #114.