### PR TITLE
feat/fuzz tests list validators 167

### DIFF
--- a/internal/validators/in_list_fuzz_test.go
+++ b/internal/validators/in_list_fuzz_test.go
@@ -1,0 +1,52 @@
+package validators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzInListValidator fuzzes the in-list validator with varied seeds
+// including Unicode, whitespace, and mixed case. It checks that values
+// present in the allowed set pass, and values outside fail.
+func FuzzInListValidator(f *testing.F) {
+	seeds := []string{"", "alpha", " BETA ", "γamma", "delta", "ALPHA", "💡idea", " space ", "tab\tchar"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	allowed := []string{"alpha", "beta", "γamma", "💡idea"}
+	vCase := NewInListValidator(allowed, false)
+	vNoCase := NewInListValidator(allowed, true)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		// exact (case sensitive)
+		req := frameworkvalidator.StringRequest{Path: path.Root("in_list"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		vCase.ValidateString(context.Background(), req, resp)
+
+		// normalize like validator for comparison purposes
+		exactAllowed := map[string]struct{}{"alpha": {}, "beta": {}, "γamma": {}, "💡idea": {}}
+		_, expectExact := exactAllowed[s]
+		if expectExact != !resp.Diagnostics.HasError() {
+			t.Fatalf("case-sensitive mismatch for %q: expect=%v hasErr=%v", s, expectExact, resp.Diagnostics.HasError())
+		}
+
+		// case-insensitive
+		req2 := frameworkvalidator.StringRequest{Path: path.Root("in_list"), ConfigValue: types.StringValue(s)}
+		resp2 := &frameworkvalidator.StringResponse{}
+		vNoCase.ValidateString(context.Background(), req2, resp2)
+
+		// expect true if lowercased version is in set
+		lower := strings.ToLower(s)
+		_, expectFold := exactAllowed[lower]
+		if expectFold != !resp2.Diagnostics.HasError() {
+			t.Fatalf("case-insensitive mismatch for %q: expect=%v hasErr=%v", s, expectFold, resp2.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/not_in_list_fuzz_test.go
+++ b/internal/validators/not_in_list_fuzz_test.go
@@ -1,0 +1,52 @@
+package validators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzNotInListValidator fuzzes the not-in-list validator. It ensures that
+// values present in the disallowed set fail, and values outside pass.
+func FuzzNotInListValidator(f *testing.F) {
+	seeds := []string{"", "alpha", " BETA ", "γamma", "delta", "ALPHA", "💡idea", " space ", "tab\tchar"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	disallowed := []string{"alpha", "beta", "γamma", "💡idea"}
+	vCase := NewNotInListValidator(disallowed, false)
+	vNoCase := NewNotInListValidator(disallowed, true)
+
+	dis := map[string]struct{}{"alpha": {}, "beta": {}, "γamma": {}, "💡idea": {}}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		// exact (case sensitive)
+		req := frameworkvalidator.StringRequest{Path: path.Root("not_in_list"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		vCase.ValidateString(context.Background(), req, resp)
+
+		_, isDis := dis[s]
+		expectError := isDis // should error if in disallowed
+		if expectError != resp.Diagnostics.HasError() {
+			t.Fatalf("case-sensitive mismatch for %q: expectError=%v hasErr=%v", s, expectError, resp.Diagnostics.HasError())
+		}
+
+		// case-insensitive
+		req2 := frameworkvalidator.StringRequest{Path: path.Root("not_in_list"), ConfigValue: types.StringValue(s)}
+		resp2 := &frameworkvalidator.StringResponse{}
+		vNoCase.ValidateString(context.Background(), req2, resp2)
+
+		lower := strings.ToLower(s)
+		_, isDisFold := dis[lower]
+		expectError2 := isDisFold
+		if expectError2 != resp2.Diagnostics.HasError() {
+			t.Fatalf("case-insensitive mismatch for %q: expectError=%v hasErr=%v", s, expectError2, resp2.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/set_equals_fuzz_test.go
+++ b/internal/validators/set_equals_fuzz_test.go
@@ -1,0 +1,53 @@
+package validators
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// FuzzSetEqualsValidator validates robustness of SetEqualsValidator against arbitrary lists.
+// We build two lists that should be equal as sets (with randomized order/duplicates),
+// and a third that differs by at least one element, then check Validate results.
+func FuzzSetEqualsValidator(f *testing.F) {
+	f.Add(int64(1))
+	f.Add(int64(42))
+	f.Add(int64(2025))
+
+	f.Fuzz(func(t *testing.T, seed int64) {
+		t.Parallel()
+		rng := rand.New(rand.NewSource(seed))
+		base := []string{"a", "b", "c", "d", "e"}
+
+		// pick a random subset of base as expected
+		expected := make([]string, 0, len(base))
+		for _, v := range base {
+			if rng.Intn(2) == 1 {
+				expected = append(expected, v)
+			}
+		}
+		if len(expected) == 0 {
+			expected = []string{"a"}
+		}
+
+		v := NewSetEquals(expected)
+
+		// Build listA equal to expected as a set, with random duplicates/order
+		listA := make([]string, 0, 10)
+		for i := 0; i < 10; i++ {
+			listA = append(listA, expected[rng.Intn(len(expected))])
+		}
+
+		// Build listB that differs by toggling one element
+		listB := append([]string{}, listA...)
+		// flip an element to something not in expected if possible
+		pool := []string{"x", "y", "z"}
+		listB[rng.Intn(len(listB))] = pool[rng.Intn(len(pool))]
+
+		if err := v.Validate(listA); err != nil {
+			t.Fatalf("expected listA to be equal set, got error: %v", err)
+		}
+		if err := v.Validate(listB); err == nil {
+			t.Fatalf("expected listB to fail set equality validation")
+		}
+	})
+}


### PR DESCRIPTION
Adds fuzz tests for list validators: in_list, not_in_list, and set_equals with Unicode/mixed-case/whitespace seeds. Includes guidance updates. Closes #167.