### PR TITLE
feat/fuzz tests list validators 167

### DIFF
--- a/internal/validators/hostname_fuzz_test.go
+++ b/internal/validators/hostname_fuzz_test.go
@@ -1,0 +1,39 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzHostnameValidator ensures the hostname validator is robust and broadly
+// consistent with RFC1123 constraints enforced by isRFC1123Hostname.
+func FuzzHostnameValidator(f *testing.F) {
+	seeds := []string{"", "example", "example.com", "-bad", "toolonglabeltoolonglabeltoolonglabeltoolonglabeltoolonglabeltool", "good-host", "bad..dots", "xn--bcher-kva.example"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := Hostname()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("hostname"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		expect := isRFC1123Hostname(s)
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: expectValid=%v diagErr=%v", s, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/password_strength_fuzz_test.go
+++ b/internal/validators/password_strength_fuzz_test.go
@@ -1,0 +1,59 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzPasswordStrengthValidator ensures no panics and basic expectation:
+// strong-looking strings should pass, weak-looking ones should fail.
+func FuzzPasswordStrengthValidator(f *testing.F) {
+	seeds := []string{"", "short", "NoNumber!", "noupper1!", "NOLOWER1!", "Valid123!", "Another$Good9"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := PasswordStrengthValidator()
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("password"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		// Heuristic expectation matching validator definition
+		strong := len(s) >= 8
+		hasUpper := false
+		hasLower := false
+		hasNum := false
+		hasSpecial := false
+		for _, r := range s {
+			switch {
+			case r >= 'A' && r <= 'Z':
+				hasUpper = true
+			case r >= 'a' && r <= 'z':
+				hasLower = true
+			case r >= '0' && r <= '9':
+				hasNum = true
+			case (r >= 33 && r <= 47) || (r >= 58 && r <= 64) || (r >= 91 && r <= 96) || (r >= 123 && r <= 126):
+				hasSpecial = true
+			}
+		}
+		strong = strong && hasUpper && hasLower && hasNum && hasSpecial
+
+		if strong != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: strong=%v diagErr=%v", s, strong, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/uuid_fuzz_test.go
+++ b/internal/validators/uuid_fuzz_test.go
@@ -1,0 +1,43 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// FuzzUUIDValidator cross-checks the validator against google/uuid parsing
+// and ensures no panics on random inputs.
+func FuzzUUIDValidator(f *testing.F) {
+	for i := 0; i < 5; i++ {
+		f.Add(uuid.NewString())
+	}
+	for _, s := range []string{"", "123", "not-a-uuid", "550e8400-e29b-41d4-a716-446655440000x"} {
+		f.Add(s)
+	}
+
+	v := UUID()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("uuid"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		_, err := uuid.Parse(s)
+		expectValid := err == nil
+		if expectValid != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: parse-ok=%v diagErr=%v", s, expectValid, resp.Diagnostics.HasError())
+		}
+	})
+}


### PR DESCRIPTION
Extend fuzz coverage: uuid, hostname, and password_strength validators. Builds on #344. Closes #167.