### PR TITLE
feat(validators): add cidr_overlap validator to detect overlapping CIDR blocks (#260)

### DIFF
--- a/examples/functions/cidr_overlap/function.tf
+++ b/examples/functions/cidr_overlap/function.tf
@@ -1,0 +1,10 @@
+locals {
+  cidr_overlap_checks = {
+    non_overlap = provider::validatefx::cidr_overlap(["10.0.0.0/24", "10.0.1.0/24"])
+  }
+}
+
+output "cidr_overlap" {
+  value = local.cidr_overlap_checks
+}
+

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -515,6 +515,16 @@ locals {
   provider_version = provider::validatefx::version()
 }
 
+locals {
+  cidr_overlap_checks = {
+    non_overlap = provider::validatefx::cidr_overlap(["10.0.0.0/24", "10.0.1.0/24"])
+  }
+}
+
+output "validatefx_cidr_overlap" {
+  value = local.cidr_overlap_checks
+}
+
 output "validatefx_email" {
   value = local.email_results
 }

--- a/internal/functions/cidr_overlap.go
+++ b/internal/functions/cidr_overlap.go
@@ -1,0 +1,94 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/The-DevOps-Daily/terraform-provider-validatefx/internal/validators"
+)
+
+type cidrOverlapFunction struct{}
+
+var _ function.Function = (*cidrOverlapFunction)(nil)
+
+// NewCIDROverlapFunction exposes the CIDR overlap validator.
+func NewCIDROverlapFunction() function.Function { return &cidrOverlapFunction{} }
+
+func (cidrOverlapFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "cidr_overlap"
+}
+
+func (cidrOverlapFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:             "Validate that provided CIDR blocks do not overlap.",
+		MarkdownDescription: "Returns true when none of the provided CIDR blocks overlap. Fails with an error when overlap is detected.",
+		Return:              function.BoolReturn{},
+		Parameters: []function.Parameter{
+			function.ListParameter{
+				Name:                "cidrs",
+				Description:         "List of CIDR blocks to check for overlap.",
+				MarkdownDescription: "List of CIDR blocks to check for overlap.",
+				ElementType:         basetypes.StringType{},
+				AllowNullValue:      true,
+				AllowUnknownValues:  true,
+			},
+		},
+	}
+}
+
+func (cidrOverlapFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var list types.List
+	if err := req.Arguments.GetArgument(ctx, 0, &list); err != nil {
+		resp.Error = function.NewFuncError(err.Error())
+		return
+	}
+
+	if list.IsUnknown() {
+		resp.Result = function.NewResultData(types.BoolUnknown())
+		return
+	}
+	if list.IsNull() {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(path.Root("cidrs"), "Missing List", "CIDR list must be provided.")
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	var elements []basetypes.StringValue
+	diags := list.ElementsAs(ctx, &elements, false)
+	if diags.HasError() {
+		diags.AddAttributeError(path.Root("cidrs"), "Invalid Elements", "CIDR list must contain only strings.")
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	cidrs := make([]string, 0, len(elements))
+	for _, el := range elements {
+		if el.IsUnknown() {
+			resp.Result = function.NewResultData(types.BoolUnknown())
+			return
+		}
+		if el.IsNull() {
+			diags := diag.Diagnostics{}
+			diags.AddAttributeError(path.Root("cidrs"), "Null Element", "CIDR list must not contain null values.")
+			resp.Error = function.FuncErrorFromDiags(ctx, diags)
+			return
+		}
+		cidrs = append(cidrs, el.ValueString())
+	}
+
+	v := validators.NewCIDROverlap()
+	if err := v.Validate(cidrs); err != nil {
+		diags := diag.Diagnostics{}
+		diags.AddAttributeError(path.Root("cidrs"), "CIDR Overlap", err.Error())
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+
+	resp.Result = function.NewResultData(basetypes.NewBoolValue(true))
+}

--- a/internal/functions/cidr_overlap_test.go
+++ b/internal/functions/cidr_overlap_test.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestCIDROverlapFunction_NoOverlap(t *testing.T) {
+	fn := NewCIDROverlapFunction()
+	ctx := context.Background()
+
+	defResp := &function.DefinitionResponse{}
+	fn.Definition(ctx, function.DefinitionRequest{}, defResp)
+
+	args := function.NewArgumentsData([]attr.Value{basetypes.NewListValueMust(
+		basetypes.StringType{},
+		[]attr.Value{basetypes.NewStringValue("10.0.0.0/24"), basetypes.NewStringValue("10.0.1.0/24")},
+	)})
+
+	runResp := &function.RunResponse{}
+	fn.Run(ctx, function.RunRequest{Arguments: args}, runResp)
+	if runResp.Error != nil {
+		t.Fatalf("unexpected error: %v", runResp.Error)
+	}
+}
+
+func TestCIDROverlapFunction_Overlap(t *testing.T) {
+	fn := NewCIDROverlapFunction()
+	ctx := context.Background()
+
+	args := function.NewArgumentsData([]attr.Value{basetypes.NewListValueMust(
+		basetypes.StringType{},
+		[]attr.Value{basetypes.NewStringValue("192.168.0.0/24"), basetypes.NewStringValue("192.168.0.0/25")},
+	)})
+
+	runResp := &function.RunResponse{}
+	fn.Run(ctx, function.RunRequest{Arguments: args}, runResp)
+	if runResp.Error == nil {
+		t.Fatalf("expected error for overlapping CIDRs")
+	}
+}

--- a/internal/functions/registry.go
+++ b/internal/functions/registry.go
@@ -48,6 +48,7 @@ func ProviderFunctionFactories() []func() function.Function {
 		NewPasswordStrengthFunction,
 		NewFQDNFunction,
 		NewJWTFunction,
+		NewCIDROverlapFunction,
 	}
 }
 

--- a/internal/validators/cidr_overlap.go
+++ b/internal/validators/cidr_overlap.go
@@ -1,0 +1,57 @@
+package validators
+
+import (
+	"fmt"
+	"net"
+)
+
+// CIDROverlapValidator validates that a set of CIDR blocks do not overlap.
+// It returns an error if any two CIDR ranges intersect or if any entry is invalid.
+type CIDROverlapValidator struct{}
+
+// NewCIDROverlap returns a new instance of the CIDR overlap validator.
+func NewCIDROverlap() *CIDROverlapValidator { return &CIDROverlapValidator{} }
+
+// Validate returns nil if no overlaps are found among the provided CIDR blocks.
+func (v *CIDROverlapValidator) Validate(cidrs []string) error {
+	if v == nil {
+		return fmt.Errorf("validator not initialized")
+	}
+
+	// Parse and normalize
+	type entry struct {
+		ipnet *net.IPNet
+		base  net.IP
+		raw   string
+		ipv6  bool
+	}
+
+	parsed := make([]entry, 0, len(cidrs))
+	for _, raw := range cidrs {
+		if raw == "" { // skip empties; treat as invalid input
+			return fmt.Errorf("invalid CIDR: empty string")
+		}
+		ip, n, err := net.ParseCIDR(raw)
+		if err != nil {
+			return fmt.Errorf("invalid CIDR %q: %w", raw, err)
+		}
+		base := ip.Mask(n.Mask)
+		parsed = append(parsed, entry{ipnet: n, base: base, raw: raw, ipv6: ip.To4() == nil})
+	}
+
+	// Compare for overlap; networks overlap if either base IP is contained in the other.
+	for i := 0; i < len(parsed); i++ {
+		for j := i + 1; j < len(parsed); j++ {
+			a, b := parsed[i], parsed[j]
+			// address family mismatch cannot overlap
+			if a.ipv6 != b.ipv6 {
+				continue
+			}
+			if a.ipnet.Contains(b.base) || b.ipnet.Contains(a.base) {
+				return fmt.Errorf("CIDR overlap detected between %q and %q", a.raw, b.raw)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/validators/cidr_overlap_test.go
+++ b/internal/validators/cidr_overlap_test.go
@@ -1,0 +1,38 @@
+package validators
+
+import "testing"
+
+func TestCIDROverlapValidator_NoOverlap(t *testing.T) {
+	v := NewCIDROverlap()
+	cases := [][]string{
+		{"10.0.0.0/24", "10.0.1.0/24"},
+		{"192.168.0.0/25", "192.168.0.128/25"},
+		{"2001:db8::/32", "2001:db9::/32"},
+	}
+	for _, c := range cases {
+		if err := v.Validate(c); err != nil {
+			t.Fatalf("expected no overlap for %v, got %v", c, err)
+		}
+	}
+}
+
+func TestCIDROverlapValidator_Overlap(t *testing.T) {
+	v := NewCIDROverlap()
+	cases := [][]string{
+		{"10.0.0.0/24", "10.0.0.128/25"},
+		{"192.168.0.0/24", "192.168.0.0/25"},
+		{"2001:db8::/32", "2001:db8:1::/48"},
+	}
+	for _, c := range cases {
+		if err := v.Validate(c); err == nil {
+			t.Fatalf("expected overlap for %v", c)
+		}
+	}
+}
+
+func TestCIDROverlapValidator_Invalid(t *testing.T) {
+	v := NewCIDROverlap()
+	if err := v.Validate([]string{"not-a-cidr", "10.0.0.0/24"}); err == nil {
+		t.Fatalf("expected error for invalid CIDR input")
+	}
+}


### PR DESCRIPTION
Implement provider::validatefx::cidr_overlap with validator + function, docs example, tests, and integration scenario. Closes #260.