### PR TITLE
test(fuzz): add fuzz tests for base64, jwt, and string_prefix validators (#350)

### DIFF
--- a/internal/validators/base64_fuzz_test.go
+++ b/internal/validators/base64_fuzz_test.go
@@ -1,0 +1,37 @@
+package validators
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzBase64Validator(f *testing.F) {
+	seeds := []string{"", "U29mdHdhcmU=", "SGVsbG8gV29ybGQh", "not*base64", "Zm9vYmFy", "===="}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := Base64Validator()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("b64"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+		_, err := base64.StdEncoding.DecodeString(s)
+		expect := err == nil
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch: decode-ok=%v diagErr=%v for %q", expect, resp.Diagnostics.HasError(), s)
+		}
+	})
+}

--- a/internal/validators/jwt_fuzz_test.go
+++ b/internal/validators/jwt_fuzz_test.go
@@ -1,0 +1,54 @@
+package validators
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzJWTValidator(f *testing.F) {
+	// minimal valid-like components
+	validSeg := base64.RawURLEncoding.EncodeToString([]byte("{}"))
+	good := strings.Join([]string{validSeg, validSeg, validSeg}, ".")
+	seeds := []string{"", good, "a.b", "a..b", "a.b.c.d", "not-a-jwt", "a.b.c"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := JWT()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("jwt"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		if strings.TrimSpace(s) == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		parts := strings.Split(s, ".")
+		expect := len(parts) == 3
+		if expect {
+			for _, p := range parts {
+				if p == "" {
+					expect = false
+					break
+				}
+				if _, err := base64.RawURLEncoding.DecodeString(p); err != nil {
+					expect = false
+					break
+				}
+			}
+		}
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: expect=%v diagErr=%v", s, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/string_prefix_fuzz_test.go
+++ b/internal/validators/string_prefix_fuzz_test.go
@@ -1,0 +1,45 @@
+package validators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzStringPrefixValidator(f *testing.F) {
+	seeds := []string{"", "tf-backend", "IAC-service", "misc", " tf- leading"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	vCase := StringPrefix([]string{"tf-", "iac-"}, false)
+	vFold := StringPrefix([]string{"tf-", "iac-"}, true)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		// case-sensitive
+		req := frameworkvalidator.StringRequest{Path: path.Root("prefix"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		vCase.ValidateString(context.Background(), req, resp)
+
+		expectExact := strings.HasPrefix(s, "tf-") || strings.HasPrefix(s, "iac-")
+		if expectExact != !resp.Diagnostics.HasError() {
+			t.Fatalf("case-sensitive mismatch for %q: expect=%v diagErr=%v", s, expectExact, resp.Diagnostics.HasError())
+		}
+
+		// case-insensitive
+		req2 := frameworkvalidator.StringRequest{Path: path.Root("prefix"), ConfigValue: types.StringValue(s)}
+		resp2 := &frameworkvalidator.StringResponse{}
+		vFold.ValidateString(context.Background(), req2, resp2)
+
+		lower := strings.ToLower(s)
+		expectFold := strings.HasPrefix(lower, "tf-") || strings.HasPrefix(lower, "iac-")
+		if expectFold != !resp2.Diagnostics.HasError() {
+			t.Fatalf("case-insensitive mismatch for %q: expect=%v diagErr=%v", s, expectFold, resp2.Diagnostics.HasError())
+		}
+	})
+}


### PR DESCRIPTION
Add fuzz suites for base64, jwt, and string_prefix validators.\n\n- base64: cross-check with encoding/base64\n- jwt: enforce 3 base64url segments\n- string_prefix: case-sensitive and case-insensitive checks (tf-/iac-)\n\nmake validate passes. References #350.