### PR TITLE
test/fuzz more three validators 350

### DIFF
--- a/internal/validators/base32_fuzz_test.go
+++ b/internal/validators/base32_fuzz_test.go
@@ -1,0 +1,37 @@
+package validators
+
+import (
+	"context"
+	"encoding/base32"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzBase32Validator(f *testing.F) {
+	seeds := []string{"", "MZXW6===", "NBSWY3DP", "INVALID*BASE32", "GEZDGNBV"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := Base32Validator()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("b32"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+		_, err := base32.StdEncoding.DecodeString(s)
+		expect := err == nil
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch: decode-ok=%v diagErr=%v for %q", expect, resp.Diagnostics.HasError(), s)
+		}
+	})
+}

--- a/internal/validators/matches_regex_fuzz_test.go
+++ b/internal/validators/matches_regex_fuzz_test.go
@@ -1,0 +1,52 @@
+package validators
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzMatchesRegexValidator(f *testing.F) {
+	seeds := []struct{ pattern, value string }{
+		{"^[a-z]+$", "abc"},
+		{"^[a-z]+$", "ABC"},
+		{"^foo|bar$", "foobar"},
+		{"(unclosed", "x"},
+		{"^$", ""},
+	}
+	for _, s := range seeds {
+		f.Add(s.pattern, s.value)
+	}
+
+	f.Fuzz(func(t *testing.T, pattern, value string) {
+		t.Parallel()
+		v := MatchesRegex(pattern)
+		req := frameworkvalidator.StringRequest{Path: path.Root("re"), ConfigValue: types.StringValue(value)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if value == "" { // empty allowed
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty value should not error (pattern=%q)", pattern)
+			}
+			return
+		}
+
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("invalid pattern should error")
+			}
+			return
+		}
+
+		expect := compiled.MatchString(value)
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for pattern=%q value=%q: match=%v diagErr=%v", pattern, value, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/username_fuzz_test.go
+++ b/internal/validators/username_fuzz_test.go
@@ -1,0 +1,38 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzUsernameValidator(f *testing.F) {
+	seeds := []string{"", "ab", "abc", "user_name", "User-Name", "123", "a_very_long_username_exceeding_limit"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := DefaultUsernameValidator()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("username"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		// Expect valid when length is within default bounds and only letters/digits/underscore
+		validChars := isValidUsername(s)
+		l := len([]rune(s))
+		expect := validChars && l >= defaultUsernameMinLength && l <= defaultUsernameMaxLength
+
+		if s == "" {
+			expect = false
+		}
+
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: expect=%v diagErr=%v", s, expect, resp.Diagnostics.HasError())
+		}
+	})
+}


### PR DESCRIPTION
Add fuzz suites for base32, matches_regex, and username validators.\n\n- base32: cross-check with encoding/base32\n- matches_regex: compile-or-error + match expectation\n- username: default bounds + allowed chars\n\nmake validate passes. Updates #350.