### PR TITLE
test/fuzz next three validators 350

### DIFF
--- a/internal/validators/integer_fuzz_test.go
+++ b/internal/validators/integer_fuzz_test.go
@@ -1,0 +1,45 @@
+package validators
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzIntegerValidator(f *testing.F) {
+	seeds := []string{"", "0", "-42", "+7", "3.14", "abc", "  10  "}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := Integer()
+	re := regexp.MustCompile(`^[+-]?\d+$`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("int"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		// Validator trims spaces; emulate that
+		trimmed := s
+		if len(s) > 0 && (s[0] == ' ' || s[len(s)-1] == ' ') {
+			trimmed = strings.TrimSpace(s)
+		}
+		if trimmed == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty/space-only should not error")
+			}
+			return
+		}
+		expect := re.MatchString(trimmed)
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q (trimmed=%q): expect=%v diagErr=%v", s, trimmed, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/ssh_public_key_fuzz_test.go
+++ b/internal/validators/ssh_public_key_fuzz_test.go
@@ -1,0 +1,46 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"golang.org/x/crypto/ssh"
+)
+
+func FuzzSSHPublicKeyValidator(f *testing.F) {
+	seeds := []string{
+		"",
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKJf0N0nH7kz5Zr4xkz0GWWJrPq9uO2m6sR3j0s8v2QG user@example",
+		"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7 bogus",
+		"not a key",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := SSHPublicKeyValidator()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("sshkey"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			// empty must error
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("empty must error for SSH key")
+			}
+			return
+		}
+
+		// Oracle via ssh.ParseAuthorizedKey
+		_, _, _, rest, err := ssh.ParseAuthorizedKey([]byte(s))
+		expect := err == nil && len(rest) == 0
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for SSH key; expect=%v diagErr=%v", expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/string_contains_fuzz_test.go
+++ b/internal/validators/string_contains_fuzz_test.go
@@ -1,0 +1,49 @@
+package validators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzStringContainsValidator(f *testing.F) {
+	seeds := []string{"", "Hello Terraform", "validatefx rocks", "no-match"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	vCase := StringContains([]string{"Terraform", "ValidateFX"}, false)
+	vFold := StringContains([]string{"Terraform", "ValidateFX"}, true)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		// case-sensitive
+		req := frameworkvalidator.StringRequest{Path: path.Root("contains"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		vCase.ValidateString(context.Background(), req, resp)
+		expectExact := strings.Contains(s, "Terraform") || strings.Contains(s, "ValidateFX")
+		if s == "" {
+			expectExact = false
+		}
+		if expectExact != !resp.Diagnostics.HasError() {
+			t.Fatalf("case-sensitive mismatch for %q: expect=%v diagErr=%v", s, expectExact, resp.Diagnostics.HasError())
+		}
+
+		// case-insensitive
+		req2 := frameworkvalidator.StringRequest{Path: path.Root("contains"), ConfigValue: types.StringValue(s)}
+		resp2 := &frameworkvalidator.StringResponse{}
+		vFold.ValidateString(context.Background(), req2, resp2)
+		lower := strings.ToLower(s)
+		expectFold := strings.Contains(lower, "terraform") || strings.Contains(lower, "validatefx")
+		if s == "" {
+			expectFold = false
+		}
+		if expectFold != !resp2.Diagnostics.HasError() {
+			t.Fatalf("case-insensitive mismatch for %q: expect=%v diagErr=%v", s, expectFold, resp2.Diagnostics.HasError())
+		}
+	})
+}


### PR DESCRIPTION
Add fuzz suites for string_contains, integer, and ssh_public_key validators.\n\n- string_contains: case-sensitive and insensitive checks\n- integer: trim/regex parity\n- ssh_public_key: oracle via ssh.ParseAuthorizedKey\n\nmake validate passes. Updates #350.