### PR TITLE
test/fuzz next three validators 350

### DIFF
--- a/internal/validators/domain_fuzz_test.go
+++ b/internal/validators/domain_fuzz_test.go
@@ -1,0 +1,37 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzDomainValidator(f *testing.F) {
+	seeds := []string{"", "example.com", "-bad.example", "good-label.example", "xn--bcher-kva.example", "too..dots"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := Domain()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("domain"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if s == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		expect := isValidDomain(s)
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: expect=%v diagErr=%v", s, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/fqdn_fuzz_test.go
+++ b/internal/validators/fqdn_fuzz_test.go
@@ -1,0 +1,48 @@
+package validators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzFQDNValidator(f *testing.F) {
+	seeds := []string{"", "app.example.com", "xn--bcher-kva.example", "bad..label", "singlelabel"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := FQDN()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("fqdn"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		if strings.TrimSpace(s) == "" {
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("empty should not error")
+			}
+			return
+		}
+
+		// basic oracle using internal helpers
+		parts := strings.Split(s, ".")
+		expect := len(parts) >= 2 && len(s) <= 253
+		if expect {
+			for _, label := range parts {
+				if label == "" || !(fqdnLabelASCII.MatchString(label) || fqdnLabelPuny.MatchString(label)) {
+					expect = false
+					break
+				}
+			}
+		}
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q: expect=%v diagErr=%v", s, expect, resp.Diagnostics.HasError())
+		}
+	})
+}

--- a/internal/validators/string_length_fuzz_test.go
+++ b/internal/validators/string_length_fuzz_test.go
@@ -1,0 +1,33 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzStringLengthValidator(f *testing.F) {
+	seeds := []string{"", "ab", "abc", "abcdef", "こんにちは", "emoji🚀"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	min, max := 3, 6
+	v := NewStringLengthValidator(&min, &max)
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("len"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+
+		// Expect valid if rune length within [3,6]
+		l := len([]rune(s))
+		expect := l >= 3 && l <= 6
+		if expect != !resp.Diagnostics.HasError() {
+			t.Fatalf("mismatch for %q (len=%d): expect=%v diagErr=%v", s, l, expect, resp.Diagnostics.HasError())
+		}
+	})
+}


### PR DESCRIPTION
Add fuzz suites for domain, fqdn, and string_length validators.\n\n- domain: oracle via internal isValidDomain\n- fqdn: label-by-label ASCII/punycode checks\n- string_length: rune-count within bounds\n\nmake validate passes. Updates #350.