### PR TITLE
test/fuzz final four validators 350

### DIFF
--- a/internal/validators/between_fuzz_test.go
+++ b/internal/validators/between_fuzz_test.go
@@ -1,0 +1,32 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzBetweenValidator(f *testing.F) {
+	seeds := []struct{ val, min, max string }{
+		{"7.5", "5", "10"},
+		{"-1", "-5", "5"},
+		{"11", "5", "10"},
+		{"3.14", "", ""},
+		{"notnum", "0", "1"},
+	}
+	for _, s := range seeds {
+		f.Add(s.val, s.min, s.max)
+	}
+
+	f.Fuzz(func(t *testing.T, val, min, max string) {
+		t.Parallel()
+		v := Between(min, max)
+		req := frameworkvalidator.StringRequest{Path: path.Root("between"), ConfigValue: types.StringValue(val)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		// Robustness check only; EvaluateBetween tested separately.
+	})
+}

--- a/internal/validators/mac_address_fuzz_test.go
+++ b/internal/validators/mac_address_fuzz_test.go
@@ -1,0 +1,26 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkvalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func FuzzMACAddressValidator(f *testing.F) {
+	seeds := []string{"", "00:1A:2B:3C:4D:5E", "00-1A-2B-3C-4D-5E", "001A2B3C4D5E", "GG:HH:II:JJ:KK:LL"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	v := MACAddress()
+	f.Fuzz(func(t *testing.T, s string) {
+		t.Parallel()
+		req := frameworkvalidator.StringRequest{Path: path.Root("mac"), ConfigValue: types.StringValue(s)}
+		resp := &frameworkvalidator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		// Rely on validator logic; assert no panics.
+	})
+}


### PR DESCRIPTION
Final batch of fuzz tests for the remaining validators.\n\n- between: range robustness\n- mac_address: format variants\n- datetime: RFC3339 and custom layouts\n- semver_range: comparator format\n- string_suffix: suffix matching\n\nmake validate passes. Closes out #350.