### PR TITLE
chore/check fuzz coverage in validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ validate: ## Run local pre-flight checks before pushing
 	go test ./...
 	$(MAKE) docs
 	go run ./scripts/check-function-coverage.go examples integration
+	go run ./scripts/check-fuzz-coverage.go
 
 fuzz-quick: ## Run short fuzz sessions for validators (1m per package)
 	@echo "Running short fuzz sessions for internal/validators..."

--- a/scripts/check-fuzz-coverage.go
+++ b/scripts/check-fuzz-coverage.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "os"
+    "path/filepath"
+    "strings"
+)
+
+func main() {
+    log.SetFlags(0)
+
+    root := "internal/validators"
+    entries, err := os.ReadDir(root)
+    if err != nil {
+        log.Fatalf("failed to read %s: %v", root, err)
+    }
+
+    var missing []string
+    for _, e := range entries {
+        name := e.Name()
+        if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+            continue
+        }
+        base := strings.TrimSuffix(name, ".go")
+        fuzz := filepath.Join(root, base+"_fuzz_test.go")
+        if _, err := os.Stat(fuzz); err != nil {
+            missing = append(missing, base)
+        }
+    }
+
+    if len(missing) > 0 {
+        log.Fatalf("fuzz coverage missing for validators: %s\nAdd *_fuzz_test.go under internal/validators for each.", strings.Join(missing, ", "))
+    }
+    fmt.Println("Fuzz coverage check passed: all validators have fuzz tests.")
+}
+


### PR DESCRIPTION
Add scripts/check-fuzz-coverage.go and wire it into make validate to enforce fuzz tests exist for every validator. Prevents new features from merging without fuzz coverage.