### PR TITLE
ci(dockerhub): push image to Docker Hub on release

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -1,0 +1,63 @@
+name: Release Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/terraform-provider-validatefx
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute tags
+        id: vars
+        run: |
+          # Derive tag from release tag or fallback to commit SHA for manual dispatch
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION="manual-${GITHUB_SHA::7}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # latest only for semver releases
+          if [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_semver=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_semver=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${ { steps.vars.outputs.is_semver == 'true' && format('{0}:{1}', env.IMAGE_NAME, steps.vars.outputs.version) || '' } }
+            ${ { steps.vars.outputs.is_semver == 'true' && format('{0}:latest', env.IMAGE_NAME) || format('{0}:{1}', env.IMAGE_NAME, steps.vars.outputs.version) } }
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and push the Docker image to Docker Hub whenever a GitHub release is published.\n\n- multi-arch builds via buildx (linux/amd64, linux/arm64)\n- tagged with the release tag (e.g., v0.5.0) and latest\n- supports manual dispatch for ad-hoc builds (tagged manual-<sha>)\n\nSecrets to add in repo settings:\n- DOCKERHUB_USERNAME: your Docker Hub username\n- DOCKERHUB_TOKEN: a Docker Hub access token (or password) with write access to the repository\n\nImage path used: /terraform-provider-validatefx\n