### PR TITLE
feat(public_ip): exclude link-local and reserved

### DIFF
--- a/internal/validators/private_ip.go
+++ b/internal/validators/private_ip.go
@@ -88,3 +88,84 @@ func isPrivateIPv6(ip net.IP) bool {
 	}
 	return false
 }
+
+// IsLinkLocalIP reports whether the IP is link-local (IPv4 169.254.0.0/16, IPv6 fe80::/10).
+func IsLinkLocalIP(ip net.IP) bool {
+	if ip4 := ip.To4(); ip4 != nil {
+		return ip4[0] == 169 && ip4[1] == 254
+	}
+	// fe80::/10 => first 10 bits 1111111010; check first byte 0xfe and next nibble 0x8..0xb
+	if len(ip) == net.IPv6len {
+		return ip[0] == 0xfe && (ip[1]&0xc0) == 0x80
+	}
+	return false
+}
+
+// IsReservedIP reports whether the IP is from commonly reserved/non-routable ranges
+// (loopback, documentation ranges, multicast, broadcast, CGNAT, etc.). This is not
+// exhaustive but covers the most relevant ranges for public routing checks.
+func IsReservedIP(ip net.IP) bool {
+	if ip4 := ip.To4(); ip4 != nil {
+		return isReservedIPv4(ip4)
+	}
+	return isReservedIPv6(ip)
+}
+
+var reservedIPv4Nets []*net.IPNet
+var reservedIPv6Nets []*net.IPNet
+
+func init() {
+	// Common non-routable/assigned ranges (IPv4)
+	v4 := []string{
+		"0.0.0.0/8",          // this network
+		"127.0.0.0/8",        // loopback
+		"100.64.0.0/10",      // CGNAT
+		"192.0.0.0/24",       // IETF Protocol Assignments
+		"192.0.2.0/24",       // TEST-NET-1
+		"198.51.100.0/24",    // TEST-NET-2
+		"203.0.113.0/24",     // TEST-NET-3
+		"224.0.0.0/4",        // multicast
+		"240.0.0.0/4",        // reserved
+		"255.255.255.255/32", // broadcast
+	}
+	for _, c := range v4 {
+		if _, n, err := net.ParseCIDR(c); err == nil {
+			reservedIPv4Nets = append(reservedIPv4Nets, n)
+		}
+	}
+
+	// Common non-routable/assigned ranges (IPv6)
+	v6 := []string{
+		"::/128",        // unspecified
+		"::1/128",       // loopback
+		"ff00::/8",      // multicast
+		"2001:db8::/32", // documentation
+	}
+	for _, c := range v6 {
+		if _, n, err := net.ParseCIDR(c); err == nil {
+			reservedIPv6Nets = append(reservedIPv6Nets, n)
+		}
+	}
+}
+
+func isReservedIPv4(ip4 net.IP) bool {
+	ip := net.IP(ip4)
+	for _, n := range reservedIPv4Nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func isReservedIPv6(ip net.IP) bool {
+	if len(ip) != net.IPv6len {
+		return false
+	}
+	for _, n := range reservedIPv6Nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validators/public_ip.go
+++ b/internal/validators/public_ip.go
@@ -40,4 +40,11 @@ func (v *publicIPValidator) ValidateString(_ context.Context, req frameworkvalid
 		resp.Diagnostics.AddAttributeError(req.Path, "Not a Public IP", fmt.Sprintf("Value %q is a private IP address.", s))
 		return
 	}
+
+	// Optionally treat link-local and reserved ranges as not public
+	// Future enhancement: make this configurable via function parameters.
+	if IsLinkLocalIP(ip) || IsReservedIP(ip) {
+		resp.Diagnostics.AddAttributeError(req.Path, "Not a Public IP", fmt.Sprintf("Value %q is not publicly routable (link-local/reserved).", s))
+		return
+	}
 }


### PR DESCRIPTION
Exclude link-local and reserved/documentation/multicast ranges from public IPs using CIDR tables.\n\nmake validate passes locally.