### PR TITLE
refactor: standardize MarkdownDescription implementations

### DIFF
--- a/internal/validators/base32.go
+++ b/internal/validators/base32.go
@@ -15,10 +15,8 @@ var _ frameworkvalidator.String = (*base32Validator)(nil)
 // Base32Validator returns a validator that verifies a string is Base32-encoded.
 func Base32Validator() frameworkvalidator.String { return base32Validator{} }
 
-func (base32Validator) Description(_ context.Context) string { return "value must be a Base32 string" }
-func (base32Validator) MarkdownDescription(_ context.Context) string {
-	return "value must be a Base32 string"
-}
+func (base32Validator) Description(_ context.Context) string             { return "value must be a Base32 string" }
+func (v base32Validator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
 
 func (base32Validator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() == "" {

--- a/internal/validators/base64.go
+++ b/internal/validators/base64.go
@@ -20,9 +20,7 @@ func (base64Validator) Description(_ context.Context) string {
 	return "value must be a base 64 string"
 }
 
-func (base64Validator) MarkdownDescription(_ context.Context) string {
-	return "value must be a base 64 string"
-}
+func (v base64Validator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
 
 func (base64Validator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() == "" {

--- a/internal/validators/between.go
+++ b/internal/validators/between.go
@@ -29,7 +29,7 @@ func (v *betweenValidator) Description(_ context.Context) string {
 }
 
 func (v *betweenValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a number between the configured minimum and maximum"
+	return v.Description(nil)
 }
 
 func (v *betweenValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/cidr.go
+++ b/internal/validators/cidr.go
@@ -23,7 +23,7 @@ func (cidrValidator) Description(_ context.Context) string {
 }
 
 func (cidrValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid IPv4 or IPv6 CIDR block"
+	return cidrValidator{}.Description(nil)
 }
 
 func (cidrValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/credit_card.go
+++ b/internal/validators/credit_card.go
@@ -23,7 +23,7 @@ func (creditCardValidator) Description(_ context.Context) string {
 }
 
 func (creditCardValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid credit card number (Luhn algorithm)"
+	return creditCardValidator{}.Description(nil)
 }
 
 func (creditCardValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/datetime.go
+++ b/internal/validators/datetime.go
@@ -28,7 +28,7 @@ func (v *dateTimeValidator) Description(_ context.Context) string {
 }
 
 func (v *dateTimeValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid datetime string"
+	return v.Description(nil)
 }
 
 func (v *dateTimeValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/domain.go
+++ b/internal/validators/domain.go
@@ -28,7 +28,7 @@ func (domainValidator) Description(_ context.Context) string {
 }
 
 func (domainValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid domain name"
+	return domainValidator{}.Description(nil)
 }
 
 func (domainValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/email.go
+++ b/internal/validators/email.go
@@ -22,7 +22,7 @@ func (emailValidator) Description(_ context.Context) string {
 }
 
 func (emailValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid email address"
+	return emailValidator{}.Description(nil)
 }
 
 func (emailValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/hostname.go
+++ b/internal/validators/hostname.go
@@ -25,7 +25,7 @@ func (hostnameValidator) Description(_ context.Context) string {
 }
 
 func (hostnameValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid hostname"
+	return hostnameValidator{}.Description(nil)
 }
 
 func (hostnameValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/ip.go
+++ b/internal/validators/ip.go
@@ -22,7 +22,7 @@ func (ipValidator) Description(_ context.Context) string {
 }
 
 func (ipValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid IP address"
+	return ipValidator{}.Description(nil)
 }
 
 func (ipValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/json.go
+++ b/internal/validators/json.go
@@ -22,7 +22,7 @@ func (jsonValidator) Description(_ context.Context) string {
 }
 
 func (jsonValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid JSON object"
+	return jsonValidator{}.Description(nil)
 }
 
 func (jsonValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/mac_address.go
+++ b/internal/validators/mac_address.go
@@ -22,7 +22,7 @@ func (macAddressValidator) Description(_ context.Context) string {
 }
 
 func (macAddressValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid MAC address"
+	return macAddressValidator{}.Description(nil)
 }
 
 func (macAddressValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/matches_regex.go
+++ b/internal/validators/matches_regex.go
@@ -22,7 +22,7 @@ func (v matchesRegexValidator) Description(_ context.Context) string {
 }
 
 func (v matchesRegexValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must match regex pattern `%s`", v.pattern)
+	return v.Description(nil)
 }
 
 func (v matchesRegexValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/phone.go
+++ b/internal/validators/phone.go
@@ -26,7 +26,7 @@ func (phoneValidator) Description(_ context.Context) string {
 
 // MarkdownDescription returns a markdown-formatted description of the validator.
 func (phoneValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid **E.164 phone number** (start with '+' followed by 1–15 digits)"
+	return phoneValidator{}.Description(nil)
 }
 
 // ValidateString performs the actual phone number validation.

--- a/internal/validators/semver.go
+++ b/internal/validators/semver.go
@@ -24,7 +24,7 @@ func (semverValidator) Description(_ context.Context) string {
 }
 
 func (semverValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a Semantic Version (SemVer 2.0.0)"
+	return semverValidator{}.Description(nil)
 }
 
 func (semverValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/url.go
+++ b/internal/validators/url.go
@@ -23,7 +23,7 @@ func (urlValidator) Description(context.Context) string {
 }
 
 func (urlValidator) MarkdownDescription(context.Context) string {
-	return "value must be a valid **URL** including scheme (e.g. `https`) and host"
+	return urlValidator{}.Description(nil)
 }
 
 func (urlValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/uuid.go
+++ b/internal/validators/uuid.go
@@ -22,7 +22,7 @@ func (uuidValidator) Description(_ context.Context) string {
 }
 
 func (uuidValidator) MarkdownDescription(_ context.Context) string {
-	return "value must be a valid UUID (versions 1-5)"
+	return uuidValidator{}.Description(nil)
 }
 
 func (uuidValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {


### PR DESCRIPTION
Reduce code duplication by delegating MarkdownDescription to Description
method across 17 validators. This ensures consistency and eliminates
duplicate description strings.

Benefits:
- Single source of truth for validator descriptions
- Easier maintenance (only one place to update descriptions)
- Consistent pattern across all validators
- Reduced lines of code (-22 insertions, +18 changes)

Affected validators: base32, base64, between, cidr, credit_card,
datetime, domain, email, hostname, ip, json, mac_address,
matches_regex, phone, semver, url, uuid
