### PR TITLE
ci: add ShellCheck linting for bash scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
       
+      - name: Lint shell scripts with ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: './scripts'
+          severity: warning
+      
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 ## Build, Test, and Development Commands
 - `go fmt ./...` — format Go sources across the repository; run before committing.
 - `go test ./...` — execute unit tests, ensuring validators and helper packages stay green.
+- `make lint-shell` — run shellcheck on bash scripts in scripts/ directory (requires shellcheck).
 - `make build` — compile the provider binary into `bin/terraform-provider-validatefx`.
 - `make install` — install the provider into the local Terraform plugin directory for manual validation.
 
@@ -17,12 +18,13 @@
 - Go 1.22+
 - Docker and Docker Compose
 - `golangci-lint` in PATH (`go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0`)
+- `shellcheck` (optional, for shell script linting - https://github.com/koalaman/shellcheck#installing)
 - `tfplugindocs` in PATH (`go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.19.2`)
 - GitHub CLI (`gh`) for PRs, issues and releases
 
 ### Developer workflow
 - Use feature branches with prefixes: `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`.
-- Before pushing, always run `make validate` (formats, vets, lints, tests, docs, function coverage, fuzz coverage).
+- Before pushing, always run `make validate` (formats, vets, lints, shell lints, tests, docs, function coverage, fuzz coverage).
 - Integration scenarios are expected to be success-only; remove or adjust any failing examples before committing.
 
 ## Coding Style & Naming Conventions


### PR DESCRIPTION
Add automated shell script linting using ShellCheck to improve code quality
and catch common bash scripting errors.

Changes:
- Add ShellCheck step to CI lint job (runs on all PRs)
- Add 'make lint-shell' target to Makefile for local validation
- Integrate shell linting into 'make validate' and 'make pre-push' workflows
- Update AGENTS.md with shellcheck documentation
- Gracefully skip shell linting if shellcheck is not installed

Benefits:
- Catch shell script errors early in CI
- Enforce best practices for bash scripts (scripts/create_issues.sh, scripts/update_changelog.sh)
- Optional local installation - build doesn't fail if shellcheck is missing
- Consistent with existing lint patterns (golangci-lint)
