### PR TITLE
refactor: eliminate redundant Description(nil) calls in MarkdownDescription methods

### DIFF
--- a/internal/validators/cidr.go
+++ b/internal/validators/cidr.go
@@ -23,7 +23,7 @@ func (cidrValidator) Description(_ context.Context) string {
 }
 
 func (cidrValidator) MarkdownDescription(_ context.Context) string {
-	return cidrValidator{}.Description(nil)
+	return "value must be an IPv4 or IPv6 CIDR block"
 }
 
 func (cidrValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/credit_card.go
+++ b/internal/validators/credit_card.go
@@ -23,7 +23,7 @@ func (creditCardValidator) Description(_ context.Context) string {
 }
 
 func (creditCardValidator) MarkdownDescription(_ context.Context) string {
-	return creditCardValidator{}.Description(nil)
+	return "value must be a valid credit card number"
 }
 
 func (creditCardValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/domain.go
+++ b/internal/validators/domain.go
@@ -28,7 +28,7 @@ func (domainValidator) Description(_ context.Context) string {
 }
 
 func (domainValidator) MarkdownDescription(_ context.Context) string {
-	return domainValidator{}.Description(nil)
+	return "value must be a valid domain name"
 }
 
 func (domainValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/email.go
+++ b/internal/validators/email.go
@@ -22,7 +22,7 @@ func (emailValidator) Description(_ context.Context) string {
 }
 
 func (emailValidator) MarkdownDescription(_ context.Context) string {
-	return emailValidator{}.Description(nil)
+	return "value must be a valid RFC 5322 email address"
 }
 
 func (emailValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/hostname.go
+++ b/internal/validators/hostname.go
@@ -25,7 +25,7 @@ func (hostnameValidator) Description(_ context.Context) string {
 }
 
 func (hostnameValidator) MarkdownDescription(_ context.Context) string {
-	return hostnameValidator{}.Description(nil)
+	return "value must be a valid hostname (RFC 1123)"
 }
 
 func (hostnameValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/ip.go
+++ b/internal/validators/ip.go
@@ -22,7 +22,7 @@ func (ipValidator) Description(_ context.Context) string {
 }
 
 func (ipValidator) MarkdownDescription(_ context.Context) string {
-	return ipValidator{}.Description(nil)
+	return "value must be a valid IPv4 or IPv6 address"
 }
 
 func (ipValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/json.go
+++ b/internal/validators/json.go
@@ -22,7 +22,7 @@ func (jsonValidator) Description(_ context.Context) string {
 }
 
 func (jsonValidator) MarkdownDescription(_ context.Context) string {
-	return jsonValidator{}.Description(nil)
+	return "value must be valid JSON"
 }
 
 func (jsonValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/mac_address.go
+++ b/internal/validators/mac_address.go
@@ -22,7 +22,7 @@ func (macAddressValidator) Description(_ context.Context) string {
 }
 
 func (macAddressValidator) MarkdownDescription(_ context.Context) string {
-	return macAddressValidator{}.Description(nil)
+	return "value must be a valid MAC address"
 }
 
 func (macAddressValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/phone.go
+++ b/internal/validators/phone.go
@@ -26,7 +26,7 @@ func (phoneValidator) Description(_ context.Context) string {
 
 // MarkdownDescription returns a markdown-formatted description of the validator.
 func (phoneValidator) MarkdownDescription(_ context.Context) string {
-	return phoneValidator{}.Description(nil)
+	return "value must be a valid E.164 phone number"
 }
 
 // ValidateString performs the actual phone number validation.

--- a/internal/validators/semver.go
+++ b/internal/validators/semver.go
@@ -24,7 +24,7 @@ func (semverValidator) Description(_ context.Context) string {
 }
 
 func (semverValidator) MarkdownDescription(_ context.Context) string {
-	return semverValidator{}.Description(nil)
+	return "value must be a valid Semantic Version (SemVer 2.0.0)"
 }
 
 func (semverValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/url.go
+++ b/internal/validators/url.go
@@ -23,7 +23,7 @@ func (urlValidator) Description(context.Context) string {
 }
 
 func (urlValidator) MarkdownDescription(context.Context) string {
-	return urlValidator{}.Description(nil)
+	return "value must be a valid HTTP(S) URL"
 }
 
 func (urlValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/uuid.go
+++ b/internal/validators/uuid.go
@@ -22,7 +22,7 @@ func (uuidValidator) Description(_ context.Context) string {
 }
 
 func (uuidValidator) MarkdownDescription(_ context.Context) string {
-	return uuidValidator{}.Description(nil)
+	return "value must be a valid UUID (versions 1-5)"
 }
 
 func (uuidValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {

--- a/internal/validators/uuidv4_only.go
+++ b/internal/validators/uuidv4_only.go
@@ -22,7 +22,7 @@ func (uuidv4OnlyValidator) Description(_ context.Context) string {
 }
 
 func (uuidv4OnlyValidator) MarkdownDescription(_ context.Context) string {
-	return uuidv4OnlyValidator{}.Description(nil)
+	return "value must be a valid UUID version 4"
 }
 
 func (uuidv4OnlyValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {


### PR DESCRIPTION
## Problem

During a codebase scan, I identified 13 validators that were using an inefficient pattern in their `MarkdownDescription` methods:

```go
func (validatorName) MarkdownDescription(_ context.Context) string {
    return validatorName{}.Description(nil)
}
```

This approach has several issues:
1. **Unnecessary overhead**: Creates a new struct instance just to call a method
2. **Context misuse**: Passes `nil` instead of using the provided `ctx` parameter
3. **Inconsistency**: Other validators already use direct return statements
4. **Maintainability**: Harder to update description strings

## Solution

Replaced the indirect `Description(nil)` calls with direct description strings:

```go
func (validatorName) MarkdownDescription(_ context.Context) string {
    return "value must be..."
}
```

## Validators Updated

- ✅ `cidr` - "value must be an IPv4 or IPv6 CIDR block"
- ✅ `credit_card` - "value must be a valid credit card number"
- ✅ `domain` - "value must be a valid domain name"
- ✅ `email` - "value must be a valid RFC 5322 email address"
- ✅ `hostname` - "value must be a valid hostname (RFC 1123)"
- ✅ `ip` - "value must be a valid IPv4 or IPv6 address"
- ✅ `json` - "value must be valid JSON"
- ✅ `mac_address` - "value must be a valid MAC address"
- ✅ `phone` - "value must be a valid E.164 phone number"
- ✅ `semver` - "value must be a valid Semantic Version (SemVer 2.0.0)"
- ✅ `url` - "value must be a valid HTTP(S) URL"
- ✅ `uuid` - "value must be a valid UUID (versions 1-5)"
- ✅ `uuidv4_only` - "value must be a valid UUID version 4"

## Benefits

- **Performance**: Eliminates unnecessary struct initialization
- **Consistency**: All validators now follow the same pattern
- **Maintainability**: Description strings are directly visible
- **Correctness**: No longer misuses the context parameter

## Validation

- ✅ `make validate` passing
- ✅ All unit tests passing
- ✅ Description tests confirm consistency
- ✅ No behavioral changes - output remains identical