### PR TITLE
refactor: standardize validator receiver types for consistency

### DIFF
--- a/internal/validators/non_negative_number.go
+++ b/internal/validators/non_negative_number.go
@@ -17,15 +17,15 @@ func NonNegativeNumber() frameworkvalidator.String {
 
 type nonNegativeNumberValidator struct{}
 
-func (v *nonNegativeNumberValidator) Description(_ context.Context) string {
+func (nonNegativeNumberValidator) Description(_ context.Context) string {
 	return "Value must be a non-negative number (zero or greater)"
 }
 
-func (v *nonNegativeNumberValidator) MarkdownDescription(ctx context.Context) string {
+func (v nonNegativeNumberValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *nonNegativeNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (nonNegativeNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/port_number.go
+++ b/internal/validators/port_number.go
@@ -17,15 +17,15 @@ func PortNumber() frameworkvalidator.String { return &portNumberValidator{} }
 
 type portNumberValidator struct{}
 
-func (v *portNumberValidator) Description(_ context.Context) string {
+func (portNumberValidator) Description(_ context.Context) string {
 	return "string must be a valid port number (1..65535)"
 }
 
-func (v *portNumberValidator) MarkdownDescription(ctx context.Context) string {
+func (v portNumberValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *portNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (portNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/port_range.go
+++ b/internal/validators/port_range.go
@@ -23,15 +23,15 @@ func PortRange() frameworkvalidator.String {
 
 type portRangeValidator struct{}
 
-func (v *portRangeValidator) Description(_ context.Context) string {
+func (portRangeValidator) Description(_ context.Context) string {
 	return "string must be a valid port range (start-end) with values 0..65535 and start <= end"
 }
 
-func (v *portRangeValidator) MarkdownDescription(ctx context.Context) string {
+func (v portRangeValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *portRangeValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (portRangeValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/positive_number.go
+++ b/internal/validators/positive_number.go
@@ -17,15 +17,15 @@ func PositiveNumber() frameworkvalidator.String {
 
 type positiveNumberValidator struct{}
 
-func (v *positiveNumberValidator) Description(_ context.Context) string {
+func (positiveNumberValidator) Description(_ context.Context) string {
 	return "Value must be a positive number (greater than zero)"
 }
 
-func (v *positiveNumberValidator) MarkdownDescription(ctx context.Context) string {
+func (v positiveNumberValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *positiveNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (positiveNumberValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/private_ip.go
+++ b/internal/validators/private_ip.go
@@ -18,15 +18,15 @@ func PrivateIP() frameworkvalidator.String {
 
 type privateIPValidator struct{}
 
-func (v *privateIPValidator) Description(_ context.Context) string {
+func (privateIPValidator) Description(_ context.Context) string {
 	return "string must be a private IP address (RFC1918 for IPv4 or unique local address for IPv6)"
 }
 
-func (v *privateIPValidator) MarkdownDescription(ctx context.Context) string {
+func (v privateIPValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *privateIPValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (privateIPValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/public_ip.go
+++ b/internal/validators/public_ip.go
@@ -16,15 +16,15 @@ func PublicIP() frameworkvalidator.String { return &publicIPValidator{} }
 
 type publicIPValidator struct{}
 
-func (v *publicIPValidator) Description(_ context.Context) string {
+func (publicIPValidator) Description(_ context.Context) string {
 	return "string must be a public IP address (not RFC1918/ULA)"
 }
 
-func (v *publicIPValidator) MarkdownDescription(ctx context.Context) string {
+func (v publicIPValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *publicIPValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (publicIPValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/slug.go
+++ b/internal/validators/slug.go
@@ -21,15 +21,15 @@ func Slug() frameworkvalidator.String {
 
 type slugValidator struct{}
 
-func (v *slugValidator) Description(_ context.Context) string {
+func (slugValidator) Description(_ context.Context) string {
 	return "Value must be a valid slug (lowercase letters, digits, and hyphens; no leading/trailing or consecutive hyphens)"
 }
 
-func (v *slugValidator) MarkdownDescription(ctx context.Context) string {
+func (v slugValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v *slugValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (slugValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}

--- a/internal/validators/uri.go
+++ b/internal/validators/uri.go
@@ -19,13 +19,13 @@ func URI() frameworkvalidator.String {
 
 type uriValidator struct{}
 
-func (v *uriValidator) Description(_ context.Context) string {
+func (uriValidator) Description(_ context.Context) string {
 	return "string must be a valid URI with a non-empty scheme and host (when required)"
 }
 
-func (v *uriValidator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
+func (v uriValidator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
 
-func (v *uriValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
+func (uriValidator) ValidateString(_ context.Context, req frameworkvalidator.StringRequest, resp *frameworkvalidator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}


### PR DESCRIPTION
This PR standardizes receiver types across validators with empty structs, changing pointer receivers to value receivers where appropriate.

## Changes

### Refactoring
- Changed pointer receivers (`*validator`) to value receivers (`validator`) for 8 validators with empty structs
- Improves consistency with existing validators like `email`, `uuid`, and `base64`
- Follows Go best practices: use value receivers for types without state

### Affected Validators
- ✅ `port_number`
- ✅ `non_negative_number`
- ✅ `positive_number`
- ✅ `slug`
- ✅ `uri`
- ✅ `port_range`
- ✅ `private_ip`
- ✅ `public_ip`

## Testing

- ✅ All unit tests pass
- ✅ `make validate` passes
- ✅ No functional changes, only receiver type adjustments

## Rationale

Validators with empty structs don't need pointer receivers since:
1. They have no internal state to modify
2. There's no performance benefit to using pointers
3. Value receivers are more idiomatic for stateless types in Go
4. Maintains consistency with other stateless validators in the codebase

This refactoring makes the codebase more maintainable and easier to understand for contributors.