### PR TITLE
chore: update CHANGELOG.md for v0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 - None.
 
+## [0.11.1] - 2025-11-24
+
+### What's Changed
+
+- refactor: extract common numeric parsing helpers to reduce duplication (#436) @bobbyonmagic
+- refactor: extract map-based validation helper to reduce duplication (#437) @bobbyonmagic
+
+### 🧰 Maintenance
+
+- refactor: extract common numeric parsing helpers (#436) @bobbyonmagic
+- refactor: extract map-based validation helper (#437) @bobbyonmagic
+
+### Contributors
+@bobbyonmagic
+
 ## [0.11.0] - 2025-11-24
 
 ### What's Changed


### PR DESCRIPTION
## Overview

Updates CHANGELOG.md to document the v0.11.1 release which was already tagged but missing changelog entries.

## Changes in v0.11.1

**Refactorings** (2):
- Extract common numeric parsing helpers (#436)
  - Added `parseFloat64()` and `parseIntInRange()` helpers
  - Refactored `positive_number`, `non_negative_number`, and `port_number` validators
  - Reduced ~20 lines of duplicate code

- Extract map-based validation helper (#437)
  - Added `validateStringInMap()` helper
  - Refactored AWS, GCP, Azure cloud region/zone validators
  - Reduced ~40 lines of duplicate code

## Note

The v0.11.1 tag was already created but the changelog was not updated at that time. This PR retroactively adds the changelog entry to keep documentation in sync with releases.